### PR TITLE
feat(DAT-1): Added receiver_loop_retry_attempts parameter to the settings

### DIFF
--- a/parsee/chat/main.py
+++ b/parsee/chat/main.py
@@ -7,19 +7,25 @@ from parsee.extraction.models.model_loader import get_llm_base_model
 from parsee.extraction.models.llm_models.prompts import Prompt
 from parsee.utils.helper import merge_answer_pieces
 from parsee.settings import chat_settings
-from tenacity import RetryError
+from tenacity import RetryError, retry, retry_if_exception_type, stop_after_attempt
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-def run_chat_with_fallback(message: Message, message_history: List[Message],
-                           document_manager: DocumentManager, receivers: List[MlModelSpecification],
-                           most_recent_references_only: bool, show_chunk_index: bool = False,
-                           single_page_processing_settings: Optional[SinglePageProcessingSettings] = None) -> List[Message]:
-    """Runs a chat with a fallback to other models if the first one fails to process the message."""
-    logger.info(f"Running chat with fallback")
-    logger.debug(f"Message: {message}")
+class ReceiverLoopRetryError(Exception):
+    """Raised when every receiver failed and the fallback loop should retry."""
+
+
+@retry(
+    stop=stop_after_attempt(chat_settings.receiver_loop_retry_attempts),
+    retry=retry_if_exception_type(ReceiverLoopRetryError),
+    reraise=True,
+)
+def _run_receiver_loop(message: Message, message_history: List[Message],
+                       document_manager: DocumentManager, receivers: List[MlModelSpecification],
+                       most_recent_references_only: bool, show_chunk_index: bool,
+                       single_page_processing_settings: Optional[SinglePageProcessingSettings]) -> List[Message]:
     for spec in receivers:
         try:
             output = run_chat(message, message_history, document_manager, spec,
@@ -29,8 +35,28 @@ def run_chat_with_fallback(message: Message, message_history: List[Message],
             continue
         logger.debug(f"Output from the model: {output}")
         return output
-    logger.warning(f"No model was able to process the message")
-    return []
+    raise ReceiverLoopRetryError()
+
+
+def run_chat_with_fallback(message: Message, message_history: List[Message],
+                           document_manager: DocumentManager, receivers: List[MlModelSpecification],
+                           most_recent_references_only: bool, show_chunk_index: bool = False,
+                           single_page_processing_settings: Optional[SinglePageProcessingSettings] = None) -> List[Message]:
+    """Runs a chat with a fallback to other models if the first one fails to process the message."""
+    logger.info(f"Running chat with fallback")
+    logger.debug(f"Message: {message}")
+
+    if len(receivers) == 0:
+        logger.warning("No fallback models configured")
+        return []
+
+    try:
+        return _run_receiver_loop(message, message_history, document_manager, receivers,
+                                  most_recent_references_only, show_chunk_index,
+                                  single_page_processing_settings)
+    except ReceiverLoopRetryError:
+        logger.warning(f"No model was able to process the message")
+        return []
 
 
 def run_chat(message: Message, message_history: List[Message],
@@ -54,7 +80,12 @@ def run_chat(message: Message, message_history: List[Message],
                 references.append(ref)
                 added_references.add(ref.reference_id())
 
-    data = document_manager.load_documents(references, model.spec.multimodal, str(message), model.spec.max_images, chat_settings.min_tokens_for_instructions_and_history, show_chunk_index)
+    data = document_manager.load_documents(references,
+                                           model.spec.multimodal,
+                                           str(message),
+                                           model.spec.max_images,
+                                           chat_settings.min_tokens_for_instructions_and_history,
+                                           show_chunk_index)
 
     # for multimodal queries, check if pages have to be processed individually
     process_pages_individually = False

--- a/parsee/chat/main.py
+++ b/parsee/chat/main.py
@@ -7,7 +7,7 @@ from parsee.extraction.models.model_loader import get_llm_base_model
 from parsee.extraction.models.llm_models.prompts import Prompt
 from parsee.utils.helper import merge_answer_pieces
 from parsee.settings import chat_settings
-from tenacity import RetryError, retry, retry_if_exception_type, stop_after_attempt
+from tenacity import RetryError, retry, retry_if_exception_type, stop_after_attempt, wait_random_exponential
 import logging
 
 logger = logging.getLogger(__name__)
@@ -20,6 +20,11 @@ class ReceiverLoopRetryError(Exception):
 @retry(
     stop=stop_after_attempt(chat_settings.receiver_loop_retry_attempts),
     retry=retry_if_exception_type(ReceiverLoopRetryError),
+    wait=wait_random_exponential(
+        multiplier=chat_settings.receiver_loop_retry_wait_multiplier,
+        min=chat_settings.receiver_loop_retry_wait_min,
+        max=chat_settings.receiver_loop_retry_wait_max
+    ),
     reraise=True,
 )
 def _run_receiver_loop(message: Message, message_history: List[Message],

--- a/parsee/settings.py
+++ b/parsee/settings.py
@@ -17,6 +17,9 @@ class ChatSettings(BaseSettings):
     retry_wait_min: int = 2
     retry_wait_max: int = 20
     receiver_loop_retry_attempts: int = 1
+    receiver_loop_retry_wait_multiplier: int = 1
+    receiver_loop_retry_wait_min: int = 2
+    receiver_loop_retry_wait_max: int = 20
     openai_key: Optional[str] = None
     replicate_key: Optional[str] = None
     together_api_key: Optional[str] = None

--- a/parsee/settings.py
+++ b/parsee/settings.py
@@ -16,6 +16,7 @@ class ChatSettings(BaseSettings):
     retry_wait_multiplier: int = 1
     retry_wait_min: int = 2
     retry_wait_max: int = 20
+    receiver_loop_retry_attempts: int = 1
     openai_key: Optional[str] = None
     replicate_key: Optional[str] = None
     together_api_key: Optional[str] = None
@@ -24,4 +25,3 @@ class ChatSettings(BaseSettings):
 
 
 chat_settings = ChatSettings()
-

--- a/tests/parsee/chat/test_main.py
+++ b/tests/parsee/chat/test_main.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from typing import Any
 
-from tenacity import RetryError, Future
+from tenacity import RetryError, Future, stop_after_attempt
 
 from parsee.chat.custom_dataclasses import Message
-from parsee.chat.main import run_chat_with_fallback
+from parsee.chat.main import _run_receiver_loop, run_chat_with_fallback
 from parsee.converters.image_creation import DiskImageCreator
 from parsee.storage.in_memory_storage import InMemoryStorageManager
 from parsee.storage.local_file_manager import LocalFileManager
@@ -40,3 +40,50 @@ def test_run_chat_with_fallback(monkeypatch):
                            spec_successes, False)
     assert result[0].text == "Success 1"
 
+
+def test_run_chat_with_fallback_retries_receiver_loop(monkeypatch):
+    """Should retry the full receiver loop after all models fail."""
+    specs = [MockMlModelSpecification(0), MockMlModelSpecification(1)]
+    calls = []
+
+    def mock_run_chat(message, message_history, document_manager, spec, most_recent_references_only, show_chunk_index,
+                      single_page_processing_max_images_trigger):
+        calls.append(spec.model_id)
+        if calls == [0, 1, 0]:
+            return [Message(text="Recovered", references=[], author=None, cost=None)]
+        raise RetryError(Future(0))
+
+    monkeypatch.setattr("parsee.chat.main.run_chat", mock_run_chat)
+    monkeypatch.setattr("parsee.chat.main._run_receiver_loop",
+                        _run_receiver_loop.retry_with(stop=stop_after_attempt(3)))
+    storage = InMemoryStorageManager(None, DiskImageCreator())
+    file_manager = LocalFileManager(storage, [])
+
+    result = run_chat_with_fallback(Message(text="Test", references=[], author=None, cost=None), [], file_manager,
+                                    specs, False)
+
+    assert result[0].text == "Recovered"
+    assert calls == [0, 1, 0]
+
+
+def test_run_chat_with_fallback_does_not_retry_receiver_loop_by_default(monkeypatch):
+    """Should preserve the existing single-pass default."""
+    specs = [MockMlModelSpecification(0), MockMlModelSpecification(1)]
+    calls = []
+
+    def mock_run_chat(message, message_history, document_manager, spec, most_recent_references_only, show_chunk_index,
+                      single_page_processing_max_images_trigger):
+        calls.append(spec.model_id)
+        raise RetryError(Future(0))
+
+    monkeypatch.setattr("parsee.chat.main.run_chat", mock_run_chat)
+    monkeypatch.setattr("parsee.chat.main._run_receiver_loop",
+                        _run_receiver_loop.retry_with(stop=stop_after_attempt(1)))
+    storage = InMemoryStorageManager(None, DiskImageCreator())
+    file_manager = LocalFileManager(storage, [])
+
+    result = run_chat_with_fallback(Message(text="Test", references=[], author=None, cost=None), [], file_manager,
+                                    specs, False)
+
+    assert result == []
+    assert calls == [0, 1]

--- a/tests/parsee/chat/test_main.py
+++ b/tests/parsee/chat/test_main.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from tenacity import RetryError, Future, stop_after_attempt
+from tenacity import RetryError, Future, stop_after_attempt, wait_none
 
 from parsee.chat.custom_dataclasses import Message
 from parsee.chat.main import _run_receiver_loop, run_chat_with_fallback
@@ -55,7 +55,7 @@ def test_run_chat_with_fallback_retries_receiver_loop(monkeypatch):
 
     monkeypatch.setattr("parsee.chat.main.run_chat", mock_run_chat)
     monkeypatch.setattr("parsee.chat.main._run_receiver_loop",
-                        _run_receiver_loop.retry_with(stop=stop_after_attempt(3)))
+                        _run_receiver_loop.retry_with(stop=stop_after_attempt(3), wait=wait_none()))
     storage = InMemoryStorageManager(None, DiskImageCreator())
     file_manager = LocalFileManager(storage, [])
 
@@ -78,7 +78,7 @@ def test_run_chat_with_fallback_does_not_retry_receiver_loop_by_default(monkeypa
 
     monkeypatch.setattr("parsee.chat.main.run_chat", mock_run_chat)
     monkeypatch.setattr("parsee.chat.main._run_receiver_loop",
-                        _run_receiver_loop.retry_with(stop=stop_after_attempt(1)))
+                        _run_receiver_loop.retry_with(stop=stop_after_attempt(1), wait=wait_none()))
     storage = InMemoryStorageManager(None, DiskImageCreator())
     file_manager = LocalFileManager(storage, [])
 


### PR DESCRIPTION
**Summary**

This PR reworks chat fallback retry behavior by adding an optional retry around the full receiver loop, instead of only trying each configured model once per request. When every receiver fails, the loop can now be retried for a configurable number of attempts before returning no result.

**Changes**
- Added `_run_receiver_loop` in [parsee/chat/main.py](/Users/tatianadembelova/projects/parsee-core/parsee/chat/main.py) and wrapped it with Tenacity retry logic.
- Introduced `ReceiverLoopRetryError` so the whole fallback sequence retries only when all receivers fail.
- Preserved existing behavior by default: `receiver_loop_retry_attempts` defaults to `1`, so current consumers still get a single pass unless they opt in.
- Added `receiver_loop_retry_attempts` to [parsee/settings.py](/Users/tatianadembelova/projects/parsee-core/parsee/settings.py).
- Expanded tests in [tests/parsee/chat/test_main.py](/Users/tatianadembelova/projects/parsee-core/tests/parsee/chat/test_main.py) to cover:
  - successful fallback to a later receiver,
  - retrying the full receiver loop and recovering on a later attempt,
  - preserving the non-retrying default path.

**Verification**

Ran `uv run pytest tests/parsee/chat/test_main.py` and all 3 tests passed.